### PR TITLE
fix permissions

### DIFF
--- a/patches/net/minecraft/advancements/AdvancementRewards.java.patch
+++ b/patches/net/minecraft/advancements/AdvancementRewards.java.patch
@@ -79,7 +79,7 @@
 +        public void sendMessage(ITextComponent component) {
 +        }
 +
-+        public boolean canUseCommand(int permLevel, String commandName) {
++        public boolean canUseCommand(int permLevel, String commandName, String perm) {
 +            return permLevel <= 2;
 +        }
 +

--- a/patches/net/minecraft/advancements/FunctionManager.java.patch
+++ b/patches/net/minecraft/advancements/FunctionManager.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/advancements/FunctionManager.java
 +++ ../src-work/minecraft/net/minecraft/advancements/FunctionManager.java
-@@ -29,8 +29,12 @@
+@@ -29,13 +29,17 @@
      private FunctionObject gameLoopFunction;
      private final ArrayDeque<FunctionManager.QueuedCommand> commandQueue = new ArrayDeque<FunctionManager.QueuedCommand>();
      private boolean isExecuting = false;
@@ -14,3 +14,9 @@
          public String getName()
          {
              return FunctionManager.this.currentGameLoopFunctionId;
+         }
+-        public boolean canUseCommand(int permLevel, String commandName)
++        public boolean canUseCommand(int permLevel, String commandName, String perm)
+         {
+             return permLevel <= 2;
+         }

--- a/patches/net/minecraft/command/CommandBase.java.patch
+++ b/patches/net/minecraft/command/CommandBase.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandBase.java
++++ ../src-work/minecraft/net/minecraft/command/CommandBase.java
+@@ -40,6 +40,7 @@
+     private static ICommandListener commandListener;
+     private static final Splitter COMMA_SPLITTER = Splitter.on(',');
+     private static final Splitter EQUAL_SPLITTER = Splitter.on('=').limit(2);
++    public String permissionNode = "minecraft";
+ 
+     protected static SyntaxErrorException toSyntaxException(JsonParseException e)
+     {
+@@ -88,7 +89,7 @@
+ 
+     public boolean checkPermission(MinecraftServer server, ICommandSender sender)
+     {
+-        return sender.canUseCommand(this.getRequiredPermissionLevel(), this.getName());
++        return sender.canUseCommand(this.getRequiredPermissionLevel(), this.getName(), this.permissionNode);
+     }
+ 
+     public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos)

--- a/patches/net/minecraft/command/CommandHandler.java.patch
+++ b/patches/net/minecraft/command/CommandHandler.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/command/CommandHandler.java
 +++ ../src-work/minecraft/net/minecraft/command/CommandHandler.java
-@@ -14,8 +14,13 @@
+@@ -14,28 +14,30 @@
  import net.minecraft.util.math.BlockPos;
  import net.minecraft.util.text.TextComponentTranslation;
  import net.minecraft.util.text.TextFormatting;
@@ -14,7 +14,12 @@
  
  public abstract class CommandHandler implements ICommandManager
  {
-@@ -27,15 +32,11 @@
+     private static final Logger LOGGER = LogManager.getLogger();
+     private final Map<String, ICommand> commandMap = Maps.<String, ICommand>newHashMap();
++    private final Map<String, ICommand> commandMod = Maps.<String, ICommand>newHashMap();
+     private final Set<ICommand> commandSet = Sets.<ICommand>newHashSet();
+ 
+     public int executeCommand(ICommandSender sender, String rawCommand)
      {
          rawCommand = rawCommand.trim();
  
@@ -31,27 +36,35 @@
          int i = 0;
  
          try
-@@ -146,16 +147,32 @@
+@@ -146,16 +148,40 @@
  
      public ICommand registerCommand(ICommand command)
      {
 -        this.commandMap.put(command.getName(), command);
 -        this.commandSet.add(command);
-+        String pre = command.getClass().getName().substring(command.getClass().getName().lastIndexOf('.')+1).toLowerCase() + "." + command.getName();
-+        return registerCommand(command, pre);
-+    }
- 
+-
 -        for (String s : command.getAliases())
--        {
++        String pre = command.getClass().getName().substring(command.getClass().getName().lastIndexOf('.')+1).toLowerCase() + "." + command.getName();
++        if (command instanceof CommandBase)
+         {
 -            ICommand icommand = this.commandMap.get(s);
-+    public ICommand registerCommand(String permissionGroup, ICommand par1ICommand)
-+    {
-+        return registerCommand(par1ICommand, permissionGroup + "." + par1ICommand.getName());
++        	if (!((CommandBase)command).permissionNode.equals("minecraft"))
++        	{
++        		pre = ((CommandBase)command).permissionNode;
++        		this.commandMod.put(command.getName(), command);
++        	}
++        }
++        return registerCommand(command, pre);
 +    }
  
 -            if (icommand == null || !icommand.getName().equals(s))
 -            {
 -                this.commandMap.put(s, command);
++    public ICommand registerCommand(String permissionGroup, ICommand par1ICommand)
++    {
++        return registerCommand(par1ICommand, permissionGroup + "." + par1ICommand.getName());
++    }
++
 +    public ICommand registerCommand(ICommand command, String permissionNode) {
 +        List<String> list = command.getAliases();
 +        this.commandMap.put(command.getName(), command);
@@ -72,3 +85,15 @@
              }
          }
  
+@@ -223,6 +249,11 @@
+     {
+         return this.commandMap;
+     }
++    
++    public Map<String, ICommand> getCommandMod()
++    {
++        return this.commandMod;
++    }
+ 
+     private int getUsernameIndex(ICommand command, String[] args) throws CommandException
+     {

--- a/patches/net/minecraft/command/CommandResultStats.java.patch
+++ b/patches/net/minecraft/command/CommandResultStats.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandResultStats.java
++++ ../src-work/minecraft/net/minecraft/command/CommandResultStats.java
+@@ -45,7 +45,7 @@
+                 {
+                     sender.sendMessage(component);
+                 }
+-                public boolean canUseCommand(int permLevel, String commandName)
++                public boolean canUseCommand(int permLevel, String commandName, String perm)
+                 {
+                     return true;
+                 }

--- a/patches/net/minecraft/command/CommandSenderWrapper.java.patch
+++ b/patches/net/minecraft/command/CommandSenderWrapper.java.patch
@@ -9,3 +9,15 @@
      @Nullable
      private final Vec3d positionVector;
      @Nullable
+@@ -76,9 +76,9 @@
+         }
+     }
+ 
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
+     {
+-        return this.permissionLevel != null && this.permissionLevel.intValue() < permLevel ? false : this.delegate.canUseCommand(permLevel, commandName);
++        return this.permissionLevel != null && this.permissionLevel.intValue() < permLevel ? false : this.delegate.canUseCommand(permLevel, commandName, perm);
+     }
+ 
+     public BlockPos getPosition()

--- a/patches/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/net/minecraft/command/EntitySelector.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/EntitySelector.java
++++ ../src-work/minecraft/net/minecraft/command/EntitySelector.java
+@@ -128,7 +128,7 @@
+     {
+         Matcher matcher = TOKEN_PATTERN.matcher(token);
+ 
+-        if (matcher.matches() && sender.canUseCommand(1, "@"))
++        if (matcher.matches() && sender.canUseCommand(1, "@", "minecraft"))
+         {
+             Map<String, String> map = getArgumentMap(matcher.group(2));
+ 

--- a/patches/net/minecraft/command/ICommandManager.java.patch
+++ b/patches/net/minecraft/command/ICommandManager.java.patch
@@ -1,0 +1,9 @@
+--- ../src-base/minecraft/net/minecraft/command/ICommandManager.java
++++ ../src-work/minecraft/net/minecraft/command/ICommandManager.java
+@@ -14,4 +14,6 @@
+     List<ICommand> getPossibleCommands(ICommandSender sender);
+ 
+     Map<String, ICommand> getCommands();
++    
++    Map<String, ICommand> getCommandMod();
+ }

--- a/patches/net/minecraft/command/ICommandSender.java.patch
+++ b/patches/net/minecraft/command/ICommandSender.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/ICommandSender.java
++++ ../src-work/minecraft/net/minecraft/command/ICommandSender.java
+@@ -22,7 +22,7 @@
+     {
+     }
+ 
+-    boolean canUseCommand(int permLevel, String commandName);
++    boolean canUseCommand(int permLevel, String commandName, String permissionNode);
+ 
+ default BlockPos getPosition()
+     {

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -1005,6 +1005,15 @@
      }
  
      public float getEyeHeight()
+@@ -2865,7 +3152,7 @@
+     {
+     }
+ 
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
+     {
+         return true;
+     }
 @@ -2897,11 +3184,11 @@
  
      public void setCommandStat(CommandResultStats.Type type, int amount)

--- a/patches/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -703,6 +703,15 @@
      {
          this.dataManager.set(RIGHT_SHOULDER_ENTITY, tag);
      }
+@@ -2531,7 +2676,7 @@
+ 
+     public boolean canUseCommandBlock()
+     {
+-        return this.capabilities.isCreativeMode && this.canUseCommand(2, "");
++        return this.capabilities.isCreativeMode && this.canUseCommand(2, "", "minecraft");
+     }
+ 
+     /**
 @@ -2671,7 +2816,7 @@
      @SuppressWarnings("unchecked")
      @Override

--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -800,9 +800,12 @@
          this.interactionManager.setGameType(gameType);
          this.connection.sendPacket(new SPacketChangeGameState(3, (float)gameType.getID()));
  
-@@ -1280,34 +1492,15 @@
+@@ -1278,36 +1490,22 @@
+         this.connection.sendPacket(new SPacketChat(component));
+     }
  
-     public boolean canUseCommand(int permLevel, String commandName)
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
      {
 -        if ("seed".equals(commandName) && !this.mcServer.isDedicatedServer())
 -        {
@@ -834,15 +837,18 @@
 +            return getBukkitEntity().isOp();
          }
 -        else
--        {
++        if (!perm.equals("minecraft"))
+         {
 -            return true;
--        }
++        	return getBukkitEntity().hasPermission(perm);
+         }
 +        return getBukkitEntity().hasPermission("minecraft.command." + commandName);
++        
 +        // CraftBukkit end
      }
  
      public String getPlayerIP()
-@@ -1320,6 +1513,14 @@
+@@ -1320,6 +1518,14 @@
  
      public void handleClientSettings(CPacketClientSettings packetIn)
      {
@@ -857,7 +863,7 @@
          this.language = packetIn.getLang();
          this.chatVisibility = packetIn.getChatVisibility();
          this.chatColours = packetIn.isColorsEnabled();
-@@ -1327,7 +1528,7 @@
+@@ -1327,7 +1533,7 @@
          this.getDataManager().set(MAIN_HAND, Byte.valueOf((byte)(packetIn.getMainHand() == EnumHandSide.LEFT ? 0 : 1)));
      }
  
@@ -866,7 +872,7 @@
      {
          return this.chatVisibility;
      }
-@@ -1402,7 +1603,7 @@
+@@ -1402,7 +1608,7 @@
          if (entity != this.spectatingEntity)
          {
              this.connection.sendPacket(new SPacketCamera(this.spectatingEntity));
@@ -875,7 +881,7 @@
          }
      }
  
-@@ -1434,7 +1635,8 @@
+@@ -1434,7 +1640,8 @@
      @Nullable
      public ITextComponent getTabListDisplayName()
      {
@@ -885,7 +891,7 @@
      }
  
      public void swingArm(EnumHand hand)
-@@ -1455,13 +1657,16 @@
+@@ -1455,13 +1662,16 @@
  
      public void setElytraFlying()
      {
@@ -905,7 +911,7 @@
      }
  
      public PlayerAdvancements getAdvancements()
-@@ -1474,4 +1679,145 @@
+@@ -1474,4 +1684,145 @@
      {
          return this.enteredNetherPosition;
      }

--- a/patches/net/minecraft/network/rcon/RConConsoleSource.java.patch
+++ b/patches/net/minecraft/network/rcon/RConConsoleSource.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/network/rcon/RConConsoleSource.java
 +++ ../src-work/minecraft/net/minecraft/network/rcon/RConConsoleSource.java
-@@ -22,6 +22,10 @@
+@@ -22,12 +22,16 @@
          return "Rcon";
      }
  
@@ -11,3 +11,10 @@
      public void sendMessage(ITextComponent component)
      {
          this.buffer.append(component.getUnformattedText());
+     }
+ 
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
+     {
+         return true;
+     }

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -999,6 +999,15 @@
      }
  
      public String getName()
+@@ -953,7 +1101,7 @@
+         LOGGER.info(component.getUnformattedText());
+     }
+ 
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
+     {
+         return true;
+     }
 @@ -993,13 +1141,11 @@
          this.folderName = name;
      }

--- a/patches/net/minecraft/tileentity/CommandBlockBaseLogic.java.patch
+++ b/patches/net/minecraft/tileentity/CommandBlockBaseLogic.java.patch
@@ -51,6 +51,15 @@
  
      public int getSuccessCount()
      {
+@@ -117,7 +131,7 @@
+         this.resultStats.readStatsFromNBT(nbt);
+     }
+ 
+-    public boolean canUseCommand(int permLevel, String commandName)
++    public boolean canUseCommand(int permLevel, String commandName, String perm)
+     {
+         return permLevel <= 2;
+     }
 @@ -152,7 +166,8 @@
                      try
                      {

--- a/patches/net/minecraft/tileentity/TileEntitySign.java.patch
+++ b/patches/net/minecraft/tileentity/TileEntitySign.java.patch
@@ -36,6 +36,15 @@
          this.stats.writeStatsToNBT(compound);
          return compound;
      }
+@@ -57,7 +63,7 @@
+             {
+                 return "Sign";
+             }
+-            public boolean canUseCommand(int permLevel, String commandName)
++            public boolean canUseCommand(int permLevel, String commandName, String perm)
+             {
+                 return permLevel <= 2; //Forge: Fixes  MC-75630 - Exploit with signs and command blocks
+             }
 @@ -79,19 +85,38 @@
              }
          };
@@ -81,6 +90,15 @@
          }
  
          this.stats.readStatsFromNBT(compound);
+@@ -154,7 +179,7 @@
+             public void sendMessage(ITextComponent component)
+             {
+             }
+-            public boolean canUseCommand(int permLevel, String commandName)
++            public boolean canUseCommand(int permLevel, String commandName, String perm)
+             {
+                 return permLevel <= 2;
+             }
 @@ -201,7 +226,12 @@
  
                  if (clickevent.getAction() == ClickEvent.Action.RUN_COMMAND)

--- a/patches/net/minecraftforge/common/util/FakePlayer.java.patch
+++ b/patches/net/minecraftforge/common/util/FakePlayer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraftforge/common/util/FakePlayer.java
++++ ../src-work/minecraft/net/minecraftforge/common/util/FakePlayer.java
+@@ -46,7 +46,7 @@
+     }
+ 
+     @Override public Vec3d getPositionVector(){ return new Vec3d(0, 0, 0); }
+-    @Override public boolean canUseCommand(int i, String s){ return false; }
++    @Override public boolean canUseCommand(int i, String s, String perm){ return false; }
+     @Override public void sendStatusMessage(ITextComponent chatComponent, boolean actionBar){}
+     @Override public void sendMessage(ITextComponent component) {}
+     @Override public void addStat(StatBase par1StatBase, int par2){}

--- a/patches/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java.patch
+++ b/patches/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java.patch
@@ -1,10 +1,25 @@
 --- ../src-base/minecraft/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java
 +++ ../src-work/minecraft/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java
-@@ -23,6 +23,7 @@
+@@ -19,10 +19,13 @@
+ 
+ package net.minecraftforge.fml.common.event;
+ 
++import net.minecraft.command.CommandBase;
+ import net.minecraft.command.CommandHandler;
  import net.minecraft.command.ICommand;
  import net.minecraft.server.MinecraftServer;
++import net.minecraftforge.fml.common.Loader;
  import net.minecraftforge.fml.common.LoaderState.ModState;
 +import org.bukkit.command.Command;
  
  /**
   * Called after {@link FMLServerAboutToStartEvent} and before {@link FMLServerStartedEvent}.
+@@ -56,6 +59,8 @@
+     public void registerServerCommand(ICommand command)
+     {
+         CommandHandler ch = (CommandHandler) getServer().getCommandManager();
++        if (command instanceof CommandBase)
++        	((CommandBase)command).permissionNode = Loader.instance().activeModContainer().getModId() +".command." + command.getName();
+         ch.registerCommand(command);
+     }
+ }

--- a/patches/net/minecraftforge/fml/relauncher/Side.java.patch
+++ b/patches/net/minecraftforge/fml/relauncher/Side.java.patch
@@ -1,0 +1,54 @@
+--- ../src-base/minecraft/net/minecraftforge/fml/relauncher/Side.java
++++ ../src-work/minecraft/net/minecraftforge/fml/relauncher/Side.java
+@@ -1,15 +1,48 @@
++/*
++ * Minecraft Forge
++ * Copyright (c) 2016-2018.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation version 2.1
++ * of the License.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ */
++
+ package net.minecraftforge.fml.relauncher;
+ 
+-public enum Side
+-{
++public enum Side {
++
++    /**
++     * The client side. Specifically, an environment where rendering capability exists.
++     * Usually in the game client.
++     */
+     CLIENT,
++    /**
++     * The server side. Specifically, an environment where NO rendering capability exists.
++     * Usually on the dedicated server.
++     */
+     SERVER;
+ 
++    /**
++     * @return If this is the server environment
++     */
+     public boolean isServer()
+     {
+-        return !this.isClient();
++        return !isClient();
+     }
+ 
++    /**
++     * @return if this is the Client environment
++     */
+     public boolean isClient()
+     {
+         return this == CLIENT;

--- a/patches/net/minecraftforge/fml/relauncher/SideOnly.java.patch
+++ b/patches/net/minecraftforge/fml/relauncher/SideOnly.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraftforge/fml/relauncher/SideOnly.java
++++ ../src-work/minecraft/net/minecraftforge/fml/relauncher/SideOnly.java
+@@ -17,6 +17,25 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+  */
+ 
++/*
++ * Minecraft Forge
++ * Copyright (c) 2016-2018.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation version 2.1
++ * of the License.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ */
++
+ package net.minecraftforge.fml.relauncher;
+ 
+ import java.lang.annotation.ElementType;

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
@@ -374,6 +374,7 @@ public final class CraftServer implements Server {
             CraftDefaultPermissions.registerCorePermissions();
             helpMap.initializeCommands();
         }
+       
     }
 
     @Override
@@ -389,6 +390,8 @@ public final class CraftServer implements Server {
         Map<String, ICommand> commands = console.getCommandManager().getCommands();
         for (ICommand cmd : commands.values()) {
             // Spigot start
+        	if (console.getCommandManager().getCommandMod().containsValue(cmd))
+        		continue;
             VanillaCommandWrapper wrapper = new VanillaCommandWrapper((CommandBase) cmd, I18n.translateToLocal(cmd.getUsage(null)));
             if (org.spigotmc.SpigotConfig.replaceCommands.contains(wrapper.getName())) {
                 if (first) {


### PR DESCRIPTION
this fix the permissions of mod.

how that work we set a permission node in CommandBase by default this permission node is minecraft
but when a mod register a command this node became modid.command.commandname
and we prevent minecraft for asking the permission minecraft.command.commandname in the methode canUseCommand in EntityPlayerMP to do this i have modify the IcommandSender to implement a string with the permision in the method canUseCommand